### PR TITLE
refactoring

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,10 @@
-final: prev: {
+final: prev: let
+  spotx = prev.fetchurl {
+    url = "https://raw.githubusercontent.com/SpotX-Official/SpotX-Bash/9b8e3a6c443f5bde5803505105a569fac8510668/spotx.sh";
+    hash = "sha256-vry/wB5mcQUNeUUwwipzGwsZhxOJYJkc2w5z9vmcRdE=";
+  };
+in {
   spotify = prev.spotify.overrideAttrs (old: {
-    srcs = [
-      old.src
-      (prev.fetchurl {
-        url = "https://raw.githubusercontent.com/SpotX-Official/SpotX-Bash/9b8e3a6c443f5bde5803505105a569fac8510668/spotx.sh";
-        hash = "sha256-vry/wB5mcQUNeUUwwipzGwsZhxOJYJkc2w5z9vmcRdE=";
-      })
-    ];
-
     nativeBuildInputs = old.nativeBuildInputs ++ (with prev; [util-linux perl unzip zip curl]);
 
     unpackPhase =
@@ -17,8 +14,8 @@ final: prev: {
       ]
       [
         ''
-          unsquashfs "$(echo $srcs | awk '{print $1}')" '/usr/share/spotify' '/usr/bin/spotify' '/meta/snap.yaml'
-          patchShebangs --build "$(echo $srcs | awk '{print $2}')"
+          unsquashfs "$src" '/usr/share/spotify' '/usr/bin/spotify' '/meta/snap.yaml'
+          patchShebangs --build ${spotx}
         ''
       ]
       old.unpackPhase;
@@ -28,7 +25,7 @@ final: prev: {
       ["runHook postInstall"]
       [
         ''
-          bash "$(echo $srcs | awk '{print $2}')" -f -P "$out/share/spotify"
+          bash ${spotx} -f -P "$out/share/spotify"
           runHook postInstall
         ''
       ]


### PR DESCRIPTION
simplifies things by removing `$(echo $srcs | awk '{print $1}')` logic